### PR TITLE
Allow empty labels

### DIFF
--- a/lib/uri/idna/base_processing.rb
+++ b/lib/uri/idna/base_processing.rb
@@ -45,7 +45,7 @@ module URI
         labels, trailing_dot = split_domain(domain)
 
         labels.map! do |label|
-          raise Error, "Empty label" if label.empty?
+          raise Error, "Empty label" if label.empty? && options.verify_dns_length?
 
           yield label
         end
@@ -62,7 +62,7 @@ module URI
         labels = domain.split(".", -1)
         trailing_dot = labels[-1] && labels[-1].empty? ? labels.pop : false
 
-        raise Error, "Empty domain" if labels.empty? || labels == [""]
+        raise Error, "Empty domain" if (labels.empty? || labels == [""]) && options.verify_dns_length?
 
         [labels, trailing_dot]
       end

--- a/lib/uri/idna/uts46/options.rb
+++ b/lib/uri/idna/uts46/options.rb
@@ -53,6 +53,10 @@ module URI
         def ignore_invalid_punycode?
           (@flags & IGNORE_INVALID_PUNYCODE) != 0
         end
+
+        def verify_dns_length?
+          false
+        end
       end
 
       # Options for ToASCII operation

--- a/spec/data/IdnaTestV2.txt
+++ b/spec/data/IdnaTestV2.txt
@@ -300,7 +300,7 @@ XN--A-Ä.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
 XN--A-A\u0308.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
 Xn--A-A\u0308.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
 Xn--A-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
-xn--xn--a--gua.pt; xn--a-ä.pt; [V2]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--xn--a--gua.pt; xn--a-ä.pt; [V2, V4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
 日本語。ＪＰ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
 日本語。JP; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
 日本語。jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp

--- a/spec/uri/uts46_spec.rb
+++ b/spec/uri/uts46_spec.rb
@@ -20,15 +20,19 @@ RSpec.describe "UTS46" do
       end
       source = test[0]
       to_unicode = test[1].empty? ? source : test[1]
-      to_unicode_status = test[2].empty? ? "[]" : test[2]
+      to_unicode_status = test[2].empty? ? [] : test[2].scan(/\w+/)
       to_ascii_n = test[3].empty? ? to_unicode : test[3]
-      to_ascii_n_status = test[4].empty? ? to_unicode_status : test[4]
+      to_ascii_n_status = test[4].empty? ? to_unicode_status : test[4].scan(/\w+/)
       to_ascii_t = test[5].empty? ? to_ascii_n : test[5]
       to_ascii_t_status = test[6].split("#").first.strip
-      to_ascii_t_status = to_ascii_n_status if to_ascii_t_status.empty?
+      to_ascii_t_status = to_ascii_t_status.empty? ? to_ascii_n_status : to_ascii_t_status.scan(/\w+/)
+
+      # Ignore X4_2 status for to_unicode
+      # UTS46 does not provide instructions for a default behavior of to_unicode in regard to length checks
+      to_unicode_status -= ["X4_2"]
 
       describe source do
-        if to_unicode_status == "[]"
+        if to_unicode_status.empty?
           it "decodes to #{to_unicode}" do
             expect(URI::IDNA.to_unicode(source)).to eq(to_unicode)
           end
@@ -38,7 +42,7 @@ RSpec.describe "UTS46" do
           end
         end
 
-        if to_ascii_n_status == "[]"
+        if to_ascii_n_status.empty?
           it "encodes to #{to_ascii_n}" do
             expect(URI::IDNA.to_ascii(source)).to eq(to_ascii_n)
           end
@@ -46,9 +50,33 @@ RSpec.describe "UTS46" do
           it "raises an error while encoding: #{to_ascii_n_status}" do
             expect { URI::IDNA.to_ascii(source) }.to raise_error(URI::IDNA::Error)
           end
+
+          if (to_ascii_n_status - %w[A4_1 A4_2]).empty?
+            it "doesn't raise with verify_dns_length: false" do
+              expect(URI::IDNA.to_ascii(source, verify_dns_length: false)).to be_a(String)
+            end
+          end
+
+          if (to_ascii_n_status - %w[V2 V3]).empty?
+            it "doesn't raise with check_hyphens: false" do
+              expect(URI::IDNA.to_ascii(source, check_hyphens: false)).to be_a(String)
+            end
+          end
+
+          if (to_ascii_n_status - %w[C1 C2]).empty?
+            it "doesn't raise with check_joiners: false" do
+              expect(URI::IDNA.to_ascii(source, check_joiners: false)).to be_a(String)
+            end
+          end
+
+          if (to_ascii_n_status - %w[B1 B2 B3 B4 B5 B6]).empty?
+            it "doesn't raise with check_bidi: false" do
+              expect(URI::IDNA.to_ascii(source, check_bidi: false)).to be_a(String)
+            end
+          end
         end
 
-        if to_ascii_t_status == "[]"
+        if to_ascii_t_status.empty?
           it "encodes transitionally to #{to_ascii_t}" do
             expect(URI::IDNA.to_ascii(source, transitional_processing: true)).to eq(to_ascii_t)
           end


### PR DESCRIPTION
This PR fixes #8

Notable changes:

- We now ignore `X4_2` error codes in the UTS46 test suite. Note that the behavior of `VerifyDnsLength` is not clearly defined for the `to_unicode` function, but it doesn't make much sense to make it stricter than `to_ascii`
- I've manually updated `IdnaTestV2.txt` to add the `V6` error code for one case to prevent false positive test errors. This error code is ported from the fixed `IdnaTestV2.txt` for Unicode 16.0.0