### PR TITLE
Fix Ruby warnings

### DIFF
--- a/lib/uri/idna/uts46/mapping.rb
+++ b/lib/uri/idna/uts46/mapping.rb
@@ -13,10 +13,10 @@ module URI
 
           MAP_REGEX = Regexp.new("#{REGEX_M_STRING}|#{REGEX_I_STRING}").freeze
           REGEX_NOT_V = Regexp.new("[^#{REGEX_V_STRING}]").freeze
-          REGEX_NOT_VD = Regexp.new("[^#{REGEX_V_STRING}|#{REGEX_D_STRING}]").freeze
-          REGEX_NOT_V3 = Regexp.new("[^#{REGEX_V_STRING}|#{REGEX_STD3_M_STRING}|#{REGEX_STD3_V_STRING}]").freeze
+          REGEX_NOT_VD = Regexp.new("[^#{REGEX_V_STRING}#{REGEX_D_STRING}]").freeze
+          REGEX_NOT_V3 = Regexp.new("[^#{REGEX_V_STRING}#{REGEX_STD3_M_STRING}#{REGEX_STD3_V_STRING}]").freeze
           REGEX_NOT_VD3 = Regexp.new(
-            "[^#{REGEX_V_STRING}|#{REGEX_D_STRING}|#{REGEX_STD3_M_STRING}|#{REGEX_STD3_V_STRING}]",
+            "[^#{REGEX_V_STRING}#{REGEX_D_STRING}#{REGEX_STD3_M_STRING}#{REGEX_STD3_V_STRING}]",
           ).freeze
 
           def call(domain_name, transitional_processing: false, use_std3_ascii_rules: true)

--- a/lib/uri/idna/validation/idna_permitted.rb
+++ b/lib/uri/idna/validation/idna_permitted.rb
@@ -8,7 +8,7 @@ module URI
       module IDNAPermitted
         class << self
           IDNA_REGEX = Regexp.new(
-            "[^(#{CODEPOINT_CLASSES['PVALID']}|#{CODEPOINT_CLASSES['CONTEXTJ']}|#{CODEPOINT_CLASSES['CONTEXTO']})]",
+            "[^#{CODEPOINT_CLASSES['PVALID']}#{CODEPOINT_CLASSES['CONTEXTJ']}#{CODEPOINT_CLASSES['CONTEXTO']}]",
           ).freeze
 
           # https://datatracker.ietf.org/doc/html/rfc5891#section-4.2.2


### PR DESCRIPTION
Currently, the following Ruby warnings come from `uri-idna`.

```
/uri-idna/lib/uri/idna/validation/idna_permitted.rb:10: warning: character class has duplicated range
/uri-idna/lib/uri/idna/uts46/mapping.rb:17: warning: character class has duplicated range
/uri-idna/lib/uri/idna/uts46/mapping.rb:18: warning: character class has duplicated range
```

All warnings are caused by the usage of `Regex`. I assume there is no need to use an alternation. So I fixed it to remove.